### PR TITLE
Bugfiks og refaktorering i excelopplastning

### DIFF
--- a/src/pages/ExcelOpplastning.less
+++ b/src/pages/ExcelOpplastning.less
@@ -58,12 +58,19 @@
     float: left;
   }
 
+  .typo-innholdstittel {
+    margin-bottom: 1rem;
+  }
+
   .fileinput {
     display: none
   }
 
   .filKnapp {
     margin: 1rem 0rem;
+  }
+  .hjelpetekst__ikon {
+    vertical-align: bottom
   }
 }
 

--- a/src/pages/ExcelOpplastning.less
+++ b/src/pages/ExcelOpplastning.less
@@ -1,7 +1,7 @@
 @import '../../node_modules/nav-frontend-core/less/core';
 @import '../../src/basic';
 
-.sykepenger {
+.excelOpplastning {
   &--alertstripe {
     padding: 0.7rem;
   }
@@ -41,59 +41,34 @@
     border-bottom: 1px solid @navMorkGra;
     padding: 1rem 0 2rem;
 
-    &:nth-child(4) {
-      border: 0;
-    }
-
     &:last-child {
       border: 0;
       padding: 1.5rem 0 4rem;
     }
   }
-  .skjemaelement__feilmelding {
-    margin-top: 0.5rem;
-    color: @redError;
-    font-weight: bold;
-    font-style: italic;
-    overflow: hidden;
-    transition: max-height 0.3s ease-out;
-    height: auto;
-    max-height: 4rem;
 
-    &.tom {
-      max-height: 0;
+  .feiloppsummeringTabell {
+    .typo-ingress {
+      padding-bottom: 1rem;
     }
   }
 
-  &__modal-tekst {
-    margin: 0rem 2.5rem 0 2.5rem;
+  .excelLogo {
+    margin: 5px;
+    float: left;
   }
 
-  &__modal-btn {
-    margin: 2.5rem 2.5rem 1rem 2.5rem;
+  .fileinput {
+    display: none
   }
 
-  &__modal-tittel {
-    margin: 2.5rem 2.5rem 2rem 2.5rem;
-  }
-
-  &__modal-avbrytt {
-    padding: 0;
-    font-family: 'Source Sans Pro', Arial, sans-serif;
-    text-decoration: underline;
-    background: none;
-    border: 0;
-    color: @navBla;
-    text-align: center;
-
-    &:focus {
-      color: @white;
-    }
+  .filKnapp {
+    margin: 1rem 0rem;
   }
 }
 
 @media (min-width: 769px) {
-  .sykepenger {
+  .excelOpplastning {
     .container {
       padding: 1rem 0 2rem;
 
@@ -112,8 +87,9 @@
   }
 }
 
+
 @media (min-width: 992px) {
-  .sykepenger {
+  .excelOpplastning {
     .bedriftsmeny {
       .virksomhetsvelger {
         margin-left: 1rem;

--- a/src/pages/ExcelOpplastning.tsx
+++ b/src/pages/ExcelOpplastning.tsx
@@ -4,7 +4,7 @@ import {FormContext, useForm} from 'react-hook-form';
 import {Hovedknapp} from 'nav-frontend-knapper';
 import {Link, useHistory} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
-import {Ingress, Normaltekst} from 'nav-frontend-typografi';
+import {Ingress, Normaltekst, Innholdstittel} from 'nav-frontend-typografi';
 import {Keys} from '../locales/keys';
 import Bedriftsmeny from '@navikt/bedriftsmeny';
 import '@navikt/bedriftsmeny/lib/bedriftsmeny.css';
@@ -77,7 +77,7 @@ const ExcelOpplastning = () => {
                         window.location.href = env.loginServiceUrl;
                     } else if (response.status === 200) {
                         response.blob().then(data => {
-                                save(data, "nav_refusjon")
+                                save(data, "nav_refusjon_kvittering.xlsx")
                                 history.push('/kvitteringExcel')
                                 setFeil([])
                             }
@@ -152,7 +152,7 @@ const ExcelOpplastning = () => {
                             for å søke om refusjon for de siste 13 dagene av arbeidsgiverperioden.</b>
                     </Ingress>
                     <div className="container">
-                        <Ingress>Last ned Excel-malen, fyll ut og last opp.</Ingress>
+                        <Innholdstittel>Last ned Excel-malen, fyll ut og last opp.</Innholdstittel>
                         <Normaltekst>
                             Har du ansatte som har vært borte i to eller flere ikke-sammenhengende perioder
                             <Link to="/">&nbsp;skal du bruke et eget skjema som du finner her</Link>.
@@ -210,7 +210,8 @@ const ExcelOpplastning = () => {
                                     om at det aktuelle fraværet skyldes covid-19-pandemien.
                                     Vær oppmerksom på at NAV kan foreta kontroller.
                                 </Normaltekst>
-                                <Hovedknapp className="knapp filKnapp">Send søknad om refusjon</Hovedknapp>
+                                <Hovedknapp id="sendExcelKnapp" disabled={file? false: true} className="filKnapp">
+                                    Send søknad om refusjon</Hovedknapp>
                             </form>
                         </FormContext>
                 </div>

--- a/src/pages/ExcelOpplastning.tsx
+++ b/src/pages/ExcelOpplastning.tsx
@@ -14,10 +14,11 @@ import {AlertStripeAdvarsel} from 'nav-frontend-alertstriper';
 import {History} from 'history';
 import Vis from '../components/Vis';
 import env from '../util/environment';
-import './Sykepenger.less';
+import './ExcelOpplastning.less';
 import Lenke from "nav-frontend-lenker";
 import excellogo from '../img/excel-logo.png';
 import save from 'save-file'
+import Hjelpetekst from "nav-frontend-hjelpetekst";
 
 interface Feil {
     melding: string,
@@ -111,7 +112,7 @@ const ExcelOpplastning = () => {
 
 
     return (
-        <div className="sykepenger">
+        <div className="excelOpplastning">
             <Vis hvis={arbeidsgivere.length === 0}>
                 <div className="limit">
                     <AlertStripeAdvarsel>
@@ -170,7 +171,7 @@ const ExcelOpplastning = () => {
                             alt må fylles ut i denne malen før du laster opp.
                         </Normaltekst>
                     </div>
-                    <div>
+                    <div className="container">
                         <label className="knapp filKnapp">
                             <input className="fileinput"
                                    type="file"
@@ -183,37 +184,45 @@ const ExcelOpplastning = () => {
                             NB, det kan maks legges inn 5000 linjer per excel-doc.
                             Om det ikke er tilstrekkelig må dere gjøre dette i flere omganger.
                         </Normaltekst>
-                    </div>
-                    <Vis hvis={feil.length > 0}>
+                        <Vis hvis={feil.length > 0}>
                         <span className="feiloppsummeringTabell feiloppsummering">
                             <Ingress>Følgende feil i dokumentet må utbedres før du laster det opp på nytt:</Ingress>
                             <table className="tabell tabell--stripet">
                                 <tbody>
                                 {feil.sort((x, y) => x.rad > y.rad ? 1 : -1).map((f, index) => (
                                     <tr key={index}>
-                                        <td>{(f.rad < 0 ? "" : "Rad " +f.rad)}</td>
-                                        <td>{(f.kolonne && f.kolonne  < 0 ? "" : f.kolonne)}</td>
+                                        <td>{(f.rad < 0 ? "" : "Rad " + f.rad)}</td>
+                                        <td>{(f.kolonne && f.kolonne < 0 ? "" : f.kolonne)}</td>
                                         <td>{f.melding}</td>
                                     </tr>
                                 ))}
                                 </tbody>
                             </table>
                         </span>
-                    </Vis>
-                        <FormContext {...methods}>
-                            <form onSubmit={methods.handleSubmit(onSubmit)} className="excelform container">
-                                <Normaltekst>
-                                    Vi erklærer at det ikke er søkt om omsorgspenger
-                                    og at arbeidstakeren ikke er permittert.
-                                    Vi erklærer at dette kravet er basert på
-                                    at fraværet skyldes arbeidstakerens opplysninger
-                                    om at det aktuelle fraværet skyldes covid-19-pandemien.
-                                    Vær oppmerksom på at NAV kan foreta kontroller.
-                                </Normaltekst>
-                                <Hovedknapp id="sendExcelKnapp" disabled={file? false: true} className="filKnapp">
-                                    Send søknad om refusjon</Hovedknapp>
-                            </form>
-                        </FormContext>
+                        </Vis>
+                    </div>
+                    <FormContext {...methods}>
+                        <form onSubmit={methods.handleSubmit(onSubmit)} className="excelform container">
+                            <Normaltekst>
+                                Vi erklærer at det ikke er søkt om omsorgspenger
+                                og at arbeidstakeren ikke er permittert.
+                                Vi erklærer at dette kravet er basert på
+                                at fraværet skyldes arbeidstakerens opplysninger
+                                om at det aktuelle fraværet skyldes covid-19-pandemien.
+                                Vær oppmerksom på at NAV kan foreta kontroller.
+                            </Normaltekst>
+                            <Hovedknapp
+                                id="sendExcelKnapp"
+                                disabled={file ? false : true}
+                                className="filKnapp"
+                            >
+                                Send søknad om refusjon
+                            </Hovedknapp>
+                            <Vis hvis={file ? false : true}>
+                            <Hjelpetekst>Du må laste opp et utfylt Excel-dokument først.</Hjelpetekst>
+                            </Vis>
+                        </form>
+                    </FormContext>
                 </div>
             </Vis>
         </div>

--- a/src/pages/ExcelOpplastning.tsx
+++ b/src/pages/ExcelOpplastning.tsx
@@ -36,11 +36,11 @@ const ExcelOpplastning = () => {
     const [fileName, setFileName] = useState('Last opp utfylt Excel-mal');
     const [file, setFile] = useState();
     const [feil, setFeil] = useState<Feil[]>([]);
-    const FILEUPLOAD_MAX_SIZE = 100000;
+    const FILEUPLOAD_MAX_SIZE = 250000;
 
     const setUploadFile = (event: any) => {
         if (event.target.files[0] && event.target.files[0].size > FILEUPLOAD_MAX_SIZE) {
-            setFeil([{rad: -1, melding: "Du kan ikke laste opp filer større enn 100 kB."}])
+            setFeil([{rad: -1, melding: "Du kan ikke laste opp filer større enn 250 kB."}])
         } else {
             setFileName(event.target.files[0].name);
             setFile(event.target.files[0]);

--- a/src/pages/ExcelOpplastning.tsx
+++ b/src/pages/ExcelOpplastning.tsx
@@ -4,7 +4,7 @@ import {FormContext, useForm} from 'react-hook-form';
 import {Hovedknapp} from 'nav-frontend-knapper';
 import {Link, useHistory} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
-import {Ingress, Normaltekst, Innholdstittel} from 'nav-frontend-typografi';
+import {Ingress, Innholdstittel, Normaltekst} from 'nav-frontend-typografi';
 import {Keys} from '../locales/keys';
 import Bedriftsmeny from '@navikt/bedriftsmeny';
 import '@navikt/bedriftsmeny/lib/bedriftsmeny.css';
@@ -19,6 +19,7 @@ import Lenke from "nav-frontend-lenker";
 import excellogo from '../img/excel-logo.png';
 import save from 'save-file'
 import Hjelpetekst from "nav-frontend-hjelpetekst";
+import {PopoverOrientering} from "nav-frontend-popover";
 
 interface Feil {
     melding: string,
@@ -211,6 +212,7 @@ const ExcelOpplastning = () => {
                                 om at det aktuelle fraværet skyldes covid-19-pandemien.
                                 Vær oppmerksom på at NAV kan foreta kontroller.
                             </Normaltekst>
+                            <span className="container">
                             <Hovedknapp
                                 id="sendExcelKnapp"
                                 disabled={file ? false : true}
@@ -219,10 +221,14 @@ const ExcelOpplastning = () => {
                                 Send søknad om refusjon
                             </Hovedknapp>
                             <Vis hvis={file ? false : true}>
-                            <Hjelpetekst>Du må laste opp et utfylt Excel-dokument først.</Hjelpetekst>
+                            <Hjelpetekst type={PopoverOrientering.Hoyre}>
+                                Du må laste opp et utfylt Excel-dokument først.
+                            </Hjelpetekst>
                             </Vis>
+                            </span>
                         </form>
                     </FormContext>
+
                 </div>
             </Vis>
         </div>


### PR DESCRIPTION
- bruk egen .less-fil
- øk øvre grense for filopplastning
- fjern gamle feilmeldinger etter ny fil er lastet opp
- refaktorer respons-handling og vis feil som ikke er på radnivå
- disable innsendingsknapp uten opplastet fil
- vis hjelpeknapp hvis innsendingsknapp er disablet