### PR TITLE
Starter flytting til gcp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
+      - 'preprod/**'
 
 env:
-  IMAGE: ghcr.io/${{ github.repository }}/sporenstreks-frontend:${{ github.sha }}
+  IMAGE: ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:${{ github.sha }}
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -73,7 +74,7 @@ jobs:
           docker push ${{ env.IMAGE }}
 
   Deploy:
-    name: Deploy til PREPROD
+    name: Deploy til dev-gcp
     needs: Docker
     runs-on: ubuntu-latest
     steps:
@@ -81,7 +82,7 @@ jobs:
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-sbs
+          CLUSTER: dev-gcp
           RESOURCE: deploy/dev.yaml
           TEAM: helsearbeidsgiver
           REF: ${{ env.COMMIT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  IMAGE: ghcr.io/${{ github.repository }}/sporenstreks-frontend:${{ github.sha }}
+  IMAGE: ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:${{ github.sha }}
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
           docker push ${{ env.IMAGE }}
 
   Deploy:
-    name: Deploy
+    name: Deploy to prod-gcp
     needs: [Docker]
     runs-on: ubuntu-latest
     steps:
@@ -88,6 +88,6 @@ jobs:
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-sbs
+          CLUSTER: prod-gcp
           RESOURCE: deploy/prod.yaml
           TEAM: helsearbeidsgiver

--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -34,10 +34,13 @@ spec:
       cpu: 400m
       memory: 256Mi
   vault:
-    enabled: true
-    paths:
-      - kvPath: apikey/apigw/dev/sporenstreks/sporenstreks-frontend_q1
-        mountPath: /apigw/sporenstreks
+    enabled: false
+  accessPolicy:
+    outbound:
+      external:
+        - host: api-gw-q1.oera.no
+  envFrom:
+    - sporenstreks-frontend-api-gw-key
   env:
     - name: API_GATEWAY
       value: https://api-gw-q1.oera.no/sporenstreks

--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -33,10 +33,13 @@ spec:
       cpu: 200m
       memory: 256Mi
   vault:
-    enabled: true
-    paths:
-      - kvPath: apikey/apigw/prod/sporenstreks/sporenstreks-frontend
-        mountPath: /apigw/sporenstreks
+    enabled: false
+  accessPolicy:
+    outbound:
+      external:
+        - host: api-gw.oera.no
+  envFrom:
+    - sporenstreks-frontend-api-gw-key
   env:
     - name: API_GATEWAY
       value: https://api-gw.oera.no/sporenstreks

--- a/nginx/20-envsubst-on-templates.sh
+++ b/nginx/20-envsubst-on-templates.sh
@@ -2,13 +2,7 @@
 
 set -e
 
-export GATEWAY_KEY="noGatewayKey"
-
-if test -d /apigw/sporenstreks;
-then
-  export GATEWAY_KEY=$(cat /apigw/sporenstreks/x-nav-apiKey)
-fi
-
+export GATEWAY_KEY=${X_NAV_APIKEY:-noGatewayKey}
 export API_GATEWAY="${API_GATEWAY:-http://localhost:8080}"
 
 ME=$(basename $0)


### PR DESCRIPTION
Bruker avviklet metode for flytting: https://confluence.adeo.no/display/PEN/GCP

Kunne brukt https://doc.nais.io/clusters/migrating-to-gcp/#how-do-i-reach-an-application-found-on-premises-from-my-application-in-gcp, men det krever at man benytter TokenX eller Azure-token.

Flyttet secrets fra vault til google secrets med https://nav-it.slack.com/archives/GQ91LT7EU/p1633964792004800

Bør heller fokusere på å flytte backend til GCP.

Husk å slette app og deployment:
```
k config use-context dev-sbs

k get deployments -n helsearbeidsgiver
k delete deployment sporenstreks-frontend -n helsearbeidsgiver --context=dev-sbs

k get app -n helsearbeidsgiver
k delete app sporenstreks-frontend -n helsearbeidsgiver --context=dev-sbs
```